### PR TITLE
Added user_type in request structure

### DIFF
--- a/Application/Signup/js/signup.js
+++ b/Application/Signup/js/signup.js
@@ -297,6 +297,7 @@ window.onload = function()
             cell_number: cellPhoneField.value,
             email: emailField.value,
             password: passwordField.value,
+            user_type: userTypeField.value
         };
 
         var xhr = new XMLHttpRequest();


### PR DESCRIPTION
@Morgan-W1 Please see the new request structure, I added the user_type as the api needs to know where to put the user. Each user goes into the users table but the retailers and administrators also need to go to their respective tables.
Please update the signup api endpoint to check the user_type and add the users to their respective tables.